### PR TITLE
dev fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,7 @@ dist/
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# Vim
+*.sw*
+
 # End of https://www.gitignore.io/api/node,visualstudiocode

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/jest": "^19.2.4",
+    "@types/node": "^10.12.18",
     "commitizen": "^2.10.1",
     "cz-conventional-changelog": "^2.0.0",
     "danger": "*",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "test": "jest",
     "predocs": "rm -rf docs/",
     "docs": "esdoc -c .esdoc.json",
-    "prepublish": "npm run build",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "prepublish": "yarn build",
+    "semantic-release": "semantic-release pre && yarn publish && semantic-release post",
     "prettier": "prettier",
-    "prettier-write": "npm run prettier -- --parser typescript --no-semi --trailing-comma es5 --write --print-width 120",
-    "prettier-project": "npm run prettier-write -- 'src/**/*.{ts,tsx}'",
+    "prettier-write": "yarn prettier --parser typescript --no-semi --trailing-comma es5 --write --print-width 120",
+    "prettier-project": "yarn prettier-write 'src/**/*.{ts,tsx}'",
     "lint": "tslint \"src/**/*.ts\""
   },
   "license": "MIT",
@@ -65,7 +65,7 @@
   "lint-staged": {
     "*.@(ts|tsx)": [
       "tslint --fix",
-      "npm run prettier-write --",
+      "yarn prettier-write --",
       "git add"
     ]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "allowJs": false,
         "pretty": true,
         "strictNullChecks": true,
-        "declaration": true
+        "declaration": true,
+        "allowSyntheticDefaultImports": true
     },
     "lib":["es2017"],
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,11 @@
   version "19.2.4"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-19.2.4.tgz#543651712535962b7dc615e18e4a381fc2687442"
 
+"@types/node@^10.12.18":
+  version "10.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
 abab@^1.0.0, abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"


### PR DESCRIPTION
I am adding a bunch of dev fixes that I think are appropriate.

After cloning the repo in order to solve #38, I had a couple of problems with `tsc`.

```
> tsc
node_modules/@octokit/rest/index.d.ts:5:23 - error TS2307: Cannot find module 'http'.
5 import * as http from "http";
                        ~~~~~~


node_modules/danger/distribution/dsl/GitHubDSL.d.ts:2:8 - error TS1192: Module '"/Volumes/Data/Documents/Avocode/repos/danger-plugin-flow/node_modules/@octokit/rest/index"' has no default export.

2 import GitHub from "@octokit/rest";
         ~~~~~~
```


I added node types to solve the first one and I `allowSyntheticDefaultImports` to solve the second one. I know these problems are in `danger` itself, but I am not sure how to solve it in their repo more generally. And I guess the change will be accepted here sooner.

Besides that, I noticed that yarn [is preffered](https://github.com/withspectrum/danger-plugin-flow/blob/master/CONTRIBUTING.md) over npm. So I am proposing a change in scripts to use yarn as well.