### PR TITLE
Add platform option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ schedule(flow({
 }))
 ```
 
+#### `platform`
+```
+schedule(flow({
+  platform: "github"
+}))
+
+schedule(flow({
+  platform: "local"
+}))
+```
+
 ## Changelog
 
 See the GitHub [release history](https://github.com/withspectrum/danger-plugin-flow/releases).


### PR DESCRIPTION
Adding `platform` option to README file. Implemented in #41